### PR TITLE
WearOS integration

### DIFF
--- a/lib/services/wearos_service.dart
+++ b/lib/services/wearos_service.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/services.dart';
+
+class WearOSService {
+  static const platform = MethodChannel('com.example.app/wearos');
+
+  Future<void> sendChatResponseToWearOS(String response) async {
+    try {
+      await platform.invokeMethod('sendChatResponse', {'response': response});
+    } catch (e) {
+      print('Failed to send response to WearOS: $e');
+    }
+  }
+}

--- a/lib/widgets/bluetooth_event_handler.dart
+++ b/lib/widgets/bluetooth_event_handler.dart
@@ -4,6 +4,7 @@ import '../services/bluetooth_manager.dart';
 import '../services/auth_service.dart';
 import '../screens/login_screen.dart';
 import 'dart:async';
+import '../services/wearos_service.dart';
 
 class BluetoothEventHandler extends StatefulWidget {
   final BluetoothManager bluetoothManager;
@@ -16,6 +17,7 @@ class BluetoothEventHandler extends StatefulWidget {
 
 class _BluetoothEventHandlerState extends State<BluetoothEventHandler> {
   final TextEditingController _inputController = TextEditingController();
+  final WearOSService _wearOSService = WearOSService();
   bool _processing = false;
 
   // This would be connected to the actual side button event from the glasses
@@ -41,6 +43,9 @@ class _BluetoothEventHandlerState extends State<BluetoothEventHandler> {
         // Display response on glasses
         await sendText(response, widget.bluetoothManager, duration: 10.0);
         
+        // Send the response to WearOS
+        await _wearOSService.sendChatResponseToWearOS(response);
+
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(content: Text('Response displayed on glasses')),


### PR DESCRIPTION
This pull request introduces integration with Wear OS by adding a new service and updating the `BluetoothEventHandler` widget to send chat responses to Wear OS devices. The key changes include the creation of a `WearOSService` class, its integration into the existing event handler, and the addition of logic to send responses to Wear OS.

### Wear OS Integration:

* [`lib/services/wearos_service.dart`](diffhunk://#diff-6196d4a4371ea5229b27e9e2e197b9cd1e77b5d99ff4fe021424fcd50dd28417R1-R13): Added a new `WearOSService` class that uses a `MethodChannel` to communicate with Wear OS devices. It includes a `sendChatResponseToWearOS` method to send chat responses.

* `lib/widgets/bluetooth_event_handler.dart`:
  - Imported the `WearOSService` to enable its usage in the widget.
  - Added an instance of `WearOSService` to the `_BluetoothEventHandlerState` class to manage Wear OS interactions.
  - Updated the response handling logic to send chat responses to Wear OS devices using the `sendChatResponseToWearOS` method.